### PR TITLE
Enable multi-project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 plugins {
   id 'application'
-  id 'checkstyle'
-  id 'pmd'
-  id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.5.RELEASE'
   id 'org.springframework.boot' version '2.0.1.RELEASE'
   id 'org.owasp.dependencycheck' version '3.1.2'
@@ -12,82 +9,123 @@ plugins {
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+// it is important to specify logback classic and core packages explicitly as libraries like spring boot
+// enforces it's own (older) version which is not recommended.
+def versions = [
+  reformLogging: '3.0.1',
+  springBoot: springBoot.class.package.implementationVersion,
+  springCloud: 'Finchley.M9',
+  springHystrix: '1.4.4.RELEASE',
+  springfoxSwagger: '2.9.0'
+]
 
-sourceSets {
-  functionalTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/functionalTest/java')
+allprojects {
+  apply plugin: 'java'
+  apply plugin: 'checkstyle'
+  apply plugin: 'pmd'
+  apply plugin: 'jacoco'
+
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+
+  sourceSets {
+    functionalTest {
+      java {
+        compileClasspath += main.output
+        runtimeClasspath += main.output
+        srcDir file('src/functionalTest/java')
+      }
+      resources.srcDir file('src/functionalTest/resources')
     }
-    resources.srcDir file('src/functionalTest/resources')
+
+    integrationTest {
+      java {
+        compileClasspath += main.output
+        runtimeClasspath += main.output
+        srcDir file('src/integrationTest/java')
+      }
+      resources.srcDir file('src/integrationTest/resources')
+    }
+
+    smokeTest {
+      java {
+        compileClasspath += main.output
+        runtimeClasspath += main.output
+        srcDir file('src/smokeTest/java')
+      }
+      resources.srcDir file('src/smokeTest/resources')
+    }
   }
 
-  integrationTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/integrationTest/java')
-    }
-    resources.srcDir file('src/integrationTest/resources')
+  tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked" << "-Werror"
   }
 
-  smokeTest {
-    java {
-      compileClasspath += main.output
-      runtimeClasspath += main.output
-      srcDir file('src/smokeTest/java')
-    }
-    resources.srcDir file('src/smokeTest/resources')
+  task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    classpath = sourceSets.functionalTest.runtimeClasspath
   }
-}
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs << "-Xlint:unchecked" << "-Werror"
-}
+  task integration(type: Test, description: 'Runs the integration tests.', group: 'Verification') {
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
 
-task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  classpath = sourceSets.functionalTest.runtimeClasspath
-}
+    // set your environment variables here
+    // environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
+  }
 
-task integration(type: Test, description: 'Runs the integration tests.', group: 'Verification') {
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
+  task smoke(type: Test) {
+    description = "Runs Smoke Tests"
+    testClassesDirs = sourceSets.smokeTest.output.classesDirs
+    classpath = sourceSets.smokeTest.runtimeClasspath
+  }
 
-  // set your environment variables here
-  // environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
-}
+  checkstyle {
+    maxWarnings = 0
+    toolVersion = '8.9'
+    // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
+    configDir = new File(rootDir, 'config/checkstyle')
+  }
 
-task smoke(type: Test) {
-  description = "Runs Smoke Tests"
-  testClassesDirs = sourceSets.smokeTest.output.classesDirs
-  classpath = sourceSets.smokeTest.runtimeClasspath
-}
+  pmd {
+    toolVersion = "6.3.0"
+    ignoreFailures = true
+    sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
+    reportsDir = file("$project.buildDir/reports/pmd")
+    ruleSetFiles = files("$rootDir/config/pmd/ruleset.xml")
+  }
 
-checkstyle {
-  maxWarnings = 0
-  toolVersion = '8.9'
-  // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
-  configDir = new File(rootDir, 'config/checkstyle')
-}
+  repositories {
+    jcenter()
+    // remove once spring sorts out their cloud artifact to proper version
+    maven {
+      url "https://repo.spring.io/libs-milestone"
+    }
+  }
 
-pmd {
-  toolVersion = "6.3.0"
-  ignoreFailures = true
-  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest, sourceSets.smokeTest]
-  reportsDir = file("$project.buildDir/reports/pmd")
-  ruleSetFiles = files("config/pmd/ruleset.xml")
+  dependencies {
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+
+    integrationTestCompile sourceSets.main.runtimeClasspath
+    integrationTestCompile sourceSets.test.runtimeClasspath
+  }
 }
 
 jacocoTestReport {
-  executionData(test, integration)
+  dependsOn = [allprojects*.test, allprojects*.integration]
+
+  executionData fileTree(rootDir.absolutePath).include("**/build/jacoco/*.exec")
+
   reports {
     xml.enabled = true
     csv.enabled = false
     xml.destination = file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+  }
+
+  doFirst {
+    executionData = files(executionData.findAll {
+      it.exists()
+    })
   }
 }
 
@@ -111,24 +149,6 @@ dependencyCheck {
   failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
   suppressionFile = 'config/owasp/suppressions.xml'
 }
-
-repositories {
-  jcenter()
-  // remove once spring sorts out their cloud artifact to proper version
-  maven {
-    url "https://repo.spring.io/libs-milestone"
-  }
-}
-
-// it is important to specify logback classic and core packages explicitly as libraries like spring boot
-// enforces it's own (older) version which is not recommended.
-def versions = [
-  reformLogging: '3.0.1',
-  springBoot: springBoot.class.package.implementationVersion,
-  springCloud: 'Finchley.M9',
-  springHystrix: '1.4.4.RELEASE',
-  springfoxSwagger: '2.9.0'
-]
 
 dependencyManagement {
   dependencies {
@@ -161,11 +181,6 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springHystrix
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix-dashboard', version: versions.springHystrix
-
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
-
-  integrationTestCompile sourceSets.main.runtimeClasspath
-  integrationTestCompile sourceSets.test.runtimeClasspath
 
   functionalTestCompile sourceSets.main.runtimeClasspath
 

--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,8 @@ dependencyManagement {
 }
 
 dependencies {
+  compileOnly project(':feature-toggle-core')
+
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'feature-toggle-api'
+
+include 'feature-toggle-core'


### PR DESCRIPTION
Separating API from implementation logic/dependency:
- Allows to use different integration regarding feature toggles
- Allows to give a stab to separate out DB dependeny
- Any other elements throughout service can be easily managed with minimal impact

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
