### PR TITLE
Feature: Web console

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/feature/FeatureProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/FeatureProvider.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.feature;
+
+import org.ff4j.FF4j;
+import org.ff4j.web.FF4jProvider;
+
+public class FeatureProvider implements FF4jProvider {
+
+    private final FF4j ff4j;
+
+    public FeatureProvider() {
+        this.ff4j = new FF4j();
+    }
+
+    @Override
+    public FF4j getFF4j() {
+        return ff4j;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
@@ -1,11 +1,18 @@
 package uk.gov.hmcts.reform.feature.config;
 
 import org.ff4j.FF4j;
+import org.ff4j.web.FF4jDispatcherServlet;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.feature.FeatureProvider;
+
+import java.util.Collections;
+
+import static org.ff4j.web.bean.WebConstants.SERVLETPARAM_FF4JPROVIDER;
 
 @ComponentScan(value = {
     "org.ff4j.spring.boot.web.api",
@@ -21,5 +28,19 @@ public class Ff4jConfiguration {
     @ConditionalOnMissingBean
     public FF4j getFF4j() {
         return new FF4j();
+    }
+
+    @Bean
+    public ServletRegistrationBean ff4jServlet() {
+        ServletRegistrationBean bean = new ServletRegistrationBean(
+            new FF4jDispatcherServlet(),
+            "/ff4j-console/*"
+        );
+
+        bean.setName("ff4j-console");
+        bean.setLoadOnStartup(1);
+        bean.setInitParameters(Collections.singletonMap(SERVLETPARAM_FF4JPROVIDER, FeatureProvider.class.getCanonicalName()));
+
+        return bean;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
@@ -39,7 +39,9 @@ public class Ff4jConfiguration {
 
         bean.setName("ff4j-console");
         bean.setLoadOnStartup(1);
-        bean.setInitParameters(Collections.singletonMap(SERVLETPARAM_FF4JPROVIDER, FeatureProvider.class.getCanonicalName()));
+        bean.setInitParameters(Collections.singletonMap(
+            SERVLETPARAM_FF4JPROVIDER, FeatureProvider.class.getCanonicalName()
+        ));
 
         return bean;
     }

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/Ff4jConfiguration.java
@@ -1,13 +1,24 @@
 package uk.gov.hmcts.reform.feature.config;
 
 import org.ff4j.FF4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+@ComponentScan(value = {
+    "org.ff4j.spring.boot.web.api",
+    "org.ff4j.services",
+    "org.ff4j.aop",
+    "org.ff4j.spring"
+})
+@ConditionalOnClass(FF4j.class)
 @Configuration
 public class Ff4jConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public FF4j getFF4j() {
         return new FF4j();
     }

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SwaggerConfiguration.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.reform.feature.config;
 
 import com.google.common.base.Predicates;
+import org.ff4j.spring.boot.web.api.config.SwaggerConfig;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import springfox.documentation.builders.PathSelectors;
@@ -12,10 +13,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import uk.gov.hmcts.reform.feature.Application;
 
-@ComponentScan(basePackages = {
-    "org.ff4j.services",
-    "org.ff4j.spring.boot.web.api.resources"
-})
+@AutoConfigureBefore(SwaggerConfig.class)
 @Configuration
 @EnableSwagger2
 @Lazy


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Integrate ff4j web console api](https://tools.hmcts.net/jira/browse/RPE-474)

### Change description ###

Following [web concepts](https://github.com/ff4j/ff4j/wiki/Web-Concepts) injecting ff4j dispatcher servlet in order to access to built-in administration web UI (screenshot attached below):

```bash
2018-05-21T12:17:27.000+0100 INFO  [main] org.ff4j.web.FF4jServlet:94:   __  __ _  _   _ 
2018-05-21T12:17:27.001+0100 INFO  [main] org.ff4j.web.FF4jServlet:95:  / _|/ _| || | (_)
2018-05-21T12:17:27.001+0100 INFO  [main] org.ff4j.web.FF4jServlet:96: | |_| |_| || |_| |
2018-05-21T12:17:27.002+0100 INFO  [main] org.ff4j.web.FF4jServlet:97: |  _|  _|__   _| |
2018-05-21T12:17:27.005+0100 INFO  [main] org.ff4j.web.FF4jServlet:98: |_| |_|    |_|_/ |
2018-05-21T12:17:27.005+0100 INFO  [main] org.ff4j.web.FF4jServlet:99:              |__/  v1.6.5
2018-05-21T12:17:27.006+0100 INFO  [main] org.ff4j.web.FF4jServlet:100:  
2018-05-21T12:17:27.009+0100 INFO  [main] org.ff4j.web.FF4jServlet:146: ff4j context has been successfully initialized - 0 feature(s)
2018-05-21T12:17:27.107+0100 INFO  [main] org.ff4j.web.FF4jServlet:180: Thymeleaf has been initialized
2018-05-21T12:17:27.115+0100 INFO  [main] org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer:201: Tomcat started on port(s): 8580 (http)
2018-05-21T12:17:27.127+0100 INFO  [main] uk.gov.hmcts.reform.feature.Application:57: Started Application in 9.237 seconds (JVM running for 12.411)
2018-05-21T12:18:33.258+0100 INFO  [http-nio-8580-exec-1] org.thymeleaf.TemplateEngine:825: [THYMELEAF] INITIALIZING TEMPLATE ENGINE
2018-05-21T12:18:33.534+0100 INFO  [http-nio-8580-exec-1] org.thymeleaf.templateresolver.AbstractTemplateResolver:99: [THYMELEAF] INITIALIZING TEMPLATE RESOLVER: org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
2018-05-21T12:18:33.536+0100 INFO  [http-nio-8580-exec-1] org.thymeleaf.templateresolver.AbstractTemplateResolver:110: [THYMELEAF] TEMPLATE RESOLVER INITIALIZED OK
2018-05-21T12:18:33.555+0100 INFO  [http-nio-8580-exec-1] org.thymeleaf.TemplateEngine.CONFIG:123: [THYMELEAF] TEMPLATE ENGINE CONFIGURATION:
[THYMELEAF] * Cache Factory implementation: org.thymeleaf.cache.StandardCacheManager
[THYMELEAF] * Template modes:
[THYMELEAF]     * XML
[THYMELEAF]     * HTML5
[THYMELEAF]     * LEGACYHTML5
[THYMELEAF]     * XHTML
[THYMELEAF]     * VALIDXML
[THYMELEAF]     * VALIDXHTML
[THYMELEAF] * Template resolvers (in order):
[THYMELEAF]     * org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
[THYMELEAF] * Message resolvers (in order):
[THYMELEAF]     * [0] customMessageResolver
[THYMELEAF] * Dialect: org.thymeleaf.standard.StandardDialect
[THYMELEAF]     * Prefix: "th"
[THYMELEAF] TEMPLATE ENGINE CONFIGURED OK
2018-05-21T12:18:33.556+0100 INFO  [http-nio-8580-exec-1] org.thymeleaf.TemplateEngine:838: [THYMELEAF] TEMPLATE ENGINE
```

API via curl also works:

```bash
$ curl -i -X GET localhost:8580/api/ff4j/store
HTTP/1.1 200 
X-Application-Context: Feature Toggle API:8580
Content-Type: application/json;charset=UTF-8
Transfer-Encoding: chunked
Date: Mon, 21 May 2018 11:23:12 GMT

{"type":"org.ff4j.store.InMemoryFeatureStore","numberOfFeatures":0,"numberOfGroups":0,"features":[],"groups":[],"cache":null}
```

![home screen](https://user-images.githubusercontent.com/1420191/40305866-4dce7ccc-5cf4-11e8-9212-424ad174f784.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
