### PR TITLE
Fix "run in docker" script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM openjdk:8-jre
 
-COPY build/bootScripts/feature-toggle-api /opt/app/bin/
-
-COPY build/libs/feature-toggle-api.jar /opt/app/lib/
+COPY build/install/feature-toggle-api /opt/app/
 
 WORKDIR /opt/app
 

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -38,8 +38,8 @@ execute_script() {
 
   if [ ${GRADLE_INSTALL} = true ]
   then
-    echo "Assembling distribution.."
-    ./gradlew assemble
+    echo "Installing distribution.."
+    ./gradlew installDist
   fi
 
   echo "Assigning environment variables.."

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -15,6 +15,7 @@ print_help() {
     --help, -h                    Print this help block
 
   Available parameters:
+    APPINSIGHTS                   Defaults to '00000000-0000-0000-0000-000000000000'
     DB_PASSWORD                   Defaults to 'password'
   "
 }
@@ -25,6 +26,7 @@ GRADLE_INSTALL=false
 FLYWAY_ENABLED=false
 
 # environment variables
+APPINSIGHTS="00000000-0000-0000-0000-000000000000"
 DB_PASSWORD="password"
 
 execute_script() {
@@ -44,6 +46,7 @@ execute_script() {
 
   echo "Assigning environment variables.."
 
+  export APPINSIGHTS_INSTRUMENTATIONKEY=${APPINSIGHTS}
   export FEATURES_DB_PASSWORD=${DB_PASSWORD}
 
   echo "Bringing up docker containers.."
@@ -64,6 +67,7 @@ while true ; do
     -f|--with-flyway) FLYWAY_ENABLED=true ; shift ;;
     -p|--param)
       case "$2" in
+        APPINSIGHTS=*) APPINSIGHTS="${2#*=}" ; shift 2 ;;
         DB_PASSWORD=*) DB_PASSWORD="${2#*=}" ; shift 2 ;;
         *) shift 2 ;;
       esac ;;

--- a/docker-compose-core.yml
+++ b/docker-compose-core.yml
@@ -11,6 +11,7 @@ services:
     image: docker.artifactory.reform.hmcts.net/reform/feature-toggle-api
     container_name: feature-toggle-api
     environment:
+      - APPINSIGHTS_INSTRUMENTATIONKEY
       - FLYWAY_ENABLED=false
       - FEATURES_DB_HOST
       - FEATURES_DB_PORT


### PR DESCRIPTION
### Change description ###

Script was based on spring boot template v2. It is not supported so has to be reverted. Including missing environment variable for app insights

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
