### PR TITLE
Allow access to api specs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
@@ -88,7 +88,7 @@ public class SecurityConfiguration {
         protected void configure(HttpSecurity http) throws Exception {
             http
                 .authorizeRequests()
-                .antMatchers("/", "/health", "/info").permitAll()
+                .antMatchers("/", "/health", "/info", "/v2/api-docs").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .csrf().disable();


### PR DESCRIPTION
### Change description ###

After applying security we need to allow access to API specification.

```json
{
  "timestamp":1527678390846,
  "status":403,
  "error":"Forbidden",
  "message":"Access Denied",
  "path":"/v2/api-docs"
}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
