### PR TITLE
Feature: logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 ## Configuring Users for feature toggle
 
-# Users and Roles
+### Users and Roles
+
 - There are three different types of users which can be configured for feature toggle
 
   - Admin: These users can login into FF4J web console and perform all operations on feature toggles(create, update, delete, enable, disable and access auditing information using web console).
@@ -21,11 +22,12 @@
  
  - Roles are dynamically assigned based on the configuration.
  
-## Configuring users using spring config file.
+### Configuring users using spring config file.
+
 - Users needs to added to below section in [application.yaml](src/main/resources/application.yaml)
 - Depending on the section in which you add users they will be assigned roles.
 - Username and password are set as environment variable through terraform configuration.
- 
+
 ```
 webconsole:
   users:
@@ -75,6 +77,20 @@ webconsole:
        SERVICENAME_ADMIN_PASSWORD          = "${local.servicename_admin_password}"
       }  
      ```
+
+## Access to API and Web Console
+
+API and Web Console is restricted to certain user roles discussed above.
+
+In order to see possible actions one should navigate to root (index) page where together with welcome message inspect the links to login/logout pages and ff4j web console.
+
+**NOTE**. If logged in user does not have sufficient access levels to web console the server response will be parsed to *403 FORBIDDEN* and, despite the fact of API allowance, user will only be able to logout.
+
+API has Basic Authorisation configured which allows following action:
+
+```bash
+curl -X PUT -u username:password -d 'let us create some feature' localhost:8580/api/ff4j/store/features
+```
 
 ## Building and deploying the application
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
@@ -26,10 +26,10 @@ public abstract class BaseTest {
     protected String testUrl;
 
     @Value("${test-admin-user}")
-    private String testAdminUser;
+    protected String testAdminUser;
 
     @Value("${test-admin-password}")
-    private String testAdminPassword;
+    protected String testAdminPassword;
 
     @Value("${test-editor-user}")
     protected String testEditorUser;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/LoginTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/LoginTest.java
@@ -19,8 +19,8 @@ public class LoginTest extends BaseTest {
 
         String location = specification
             .contentType(ContentType.URLENC)
-            .formParam("username", "user")
-            .formParam("password", "password")
+            .formParam("username", testReadUser)
+            .formParam("password", testReadPassword)
             .post("/login")
             .then()
             .statusCode(FOUND.value())

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/LoginTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/LoginTest.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.feature;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpStatus.FOUND;
+
+public class LoginTest extends BaseTest {
+
+    @Category(SmokeTestCategory.class)
+    @Test
+    public void should_allow_user_to_login_and_redirected_to_home_page() {
+        RequestSpecification specification = requestSpecification();
+
+        String location = specification
+            .contentType(ContentType.URLENC)
+            .formParam("username", "user")
+            .formParam("password", "password")
+            .post("/login")
+            .then()
+            .statusCode(FOUND.value())
+            .extract()
+            .header(LOCATION);
+
+        assertThat(location).contains("/?login");
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/UnauthorizedAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/UnauthorizedAccessTest.java
@@ -4,7 +4,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 public class UnauthorizedAccessTest extends BaseTest {
@@ -26,7 +28,9 @@ public class UnauthorizedAccessTest extends BaseTest {
             .auth().none()
             .get(FF4J_WEB_CONSOLE_URL)
             .then()
-            .statusCode(UNAUTHORIZED.value());
+            .statusCode(OK.value())
+            .and()
+            .body("html.head.title", equalTo("Login Page"));
     }
 
     @Category(SmokeTestCategory.class)
@@ -46,6 +50,8 @@ public class UnauthorizedAccessTest extends BaseTest {
             .auth().preemptive().basic(testReadUser, testReadPassword)
             .get(FF4J_WEB_CONSOLE_URL)
             .then()
-            .statusCode(FORBIDDEN.value());
+            .statusCode(OK.value())
+            .and()
+            .body("html.head.title", equalTo("Login Page"));
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
@@ -1,24 +1,33 @@
 package uk.gov.hmcts.reform.feature.webconsole;
 
-import io.restassured.response.Response;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.feature.BaseTest;
 import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpStatus.FOUND;
 
 public class AdminAccessTest extends BaseTest {
 
     @Category(SmokeTestCategory.class)
     @Test
-    public void should_allow_admin_to_access_ff4j_web_console() {
-        Response response = requestSpecification()
-            .get(FF4J_WEB_CONSOLE_URL)
-            .andReturn();
+    public void should_allow_admin_to_login_to_ff4j_web_console() {
+        RequestSpecification specification = requestSpecification();
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.body().htmlPath().getString("html.head.title")).isEqualTo("FF4J - Home");
+        String location = specification
+            .contentType(ContentType.URLENC)
+            .formParam("username", "admin")
+            .formParam("password", "admin")
+            .post("/login")
+            .then()
+            .statusCode(FOUND.value())
+            .extract()
+            .header(LOCATION);
+
+        assertThat(location).contains(FF4J_WEB_CONSOLE_URL);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
@@ -20,8 +20,8 @@ public class AdminAccessTest extends BaseTest {
 
         String location = specification
             .contentType(ContentType.URLENC)
-            .formParam("username", "admin")
-            .formParam("password", "admin")
+            .formParam("username", testAdminUser)
+            .formParam("password", testAdminPassword)
             .post("/login")
             .then()
             .statusCode(FOUND.value())

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
@@ -17,7 +17,7 @@ public class AdminAccessTest extends BaseTest {
 
     @Category(SmokeTestCategory.class)
     @Test
-    public void should_verify_login_logour_journey() {
+    public void should_verify_login_logout_journey() {
         RequestSpecification specification = requestSpecification();
         String sessionCookieName = "JSESSIONID";
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
@@ -19,9 +19,9 @@ public class AdminAccessTest extends BaseTest {
     @Test
     public void should_verify_login_logour_journey() {
         RequestSpecification specification = requestSpecification();
-        String jSessionHeader = "JSESSIONID";
+        String sessionCookieName = "JSESSIONID";
 
-        String jSessionId = specification
+        String sessionCookieValue = specification
             .contentType(ContentType.URLENC)
             .formParam("username", testAdminUser)
             .formParam("password", testAdminPassword)
@@ -29,23 +29,23 @@ public class AdminAccessTest extends BaseTest {
             .then()
             .statusCode(FOUND.value())
             .extract()
-            .cookie(jSessionHeader);
+            .cookie(sessionCookieName);
 
         specification
-            .cookie(jSessionHeader, jSessionId)
+            .cookie(sessionCookieName, sessionCookieValue)
             .get(FF4J_WEB_CONSOLE_URL)
             .then()
             .statusCode(OK.value())
             .body("html.head.title", equalTo("FF4J - Home"));
 
         specification
-            .cookie(jSessionHeader, jSessionId)
+            .cookie(sessionCookieName, sessionCookieValue)
             .get("/logout")
             .then()
             .statusCode(OK.value());
 
         specification
-            .cookie(jSessionHeader, jSessionId)
+            .cookie(sessionCookieName, sessionCookieValue)
             .get(FF4J_WEB_CONSOLE_URL)
             .then()
             .statusCode(OK.value())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/feature/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/feature/controllers/GetWelcomeTest.java
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,8 +22,12 @@ public class GetWelcomeTest {
 
     @Test
     public void should_welcome_upon_root_request_with_200_response_code() throws Exception {
-        MvcResult response = mockMvc.perform(get("/")).andExpect(status().isOk()).andReturn();
+        String response = mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
 
-        assertThat(response.getResponse().getContentAsString()).startsWith("Welcome");
+        assertThat(response).contains(RootController.TITLE);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
@@ -15,9 +15,9 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import uk.gov.hmcts.reform.feature.webconsole.WebconsoleUserConfig;
 
 import java.io.IOException;
@@ -142,7 +142,9 @@ public class SecurityConfiguration {
                                                 HttpServletResponse response,
                                                 Authentication authentication) throws IOException, ServletException {
                 boolean isAdmin = authentication.getAuthorities().stream().anyMatch(authority ->
-                    authority.getAuthority().equals(ROLE_ADMIN)
+                    // since roles are created with automatic prefix of `ROLE_` - authorities come in raw
+                    // need to strip the prefix to match successfully
+                    authority.getAuthority().replaceFirst("ROLE_", "").equals(ROLE_ADMIN)
                 );
                 String targetUrl = isAdmin ? "/ff4j-web-console/home" : "/?login";
 

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
@@ -142,7 +142,7 @@ public class SecurityConfiguration {
                                                 HttpServletResponse response,
                                                 Authentication authentication) throws IOException, ServletException {
                 boolean isAdmin = authentication.getAuthorities().stream().anyMatch(authority ->
-                    authority.getAuthority().equals("ROLE_ADMIN")
+                    authority.getAuthority().equals(ROLE_ADMIN)
                 );
 
                 if (isAdmin) {

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
@@ -141,7 +141,15 @@ public class SecurityConfiguration {
             public void onAuthenticationSuccess(HttpServletRequest request,
                                                 HttpServletResponse response,
                                                 Authentication authentication) throws IOException, ServletException {
-                response.sendRedirect(response.encodeRedirectURL("/ff4j-web-console/home"));
+                boolean isAdmin = authentication.getAuthorities().stream().anyMatch(authority ->
+                    authority.getAuthority().equals("ROLE_ADMIN")
+                );
+
+                if (isAdmin) {
+                    response.sendRedirect(response.encodeRedirectURL("/ff4j-web-console/home"));
+                } else {
+                    response.sendRedirect(response.encodeRedirectURL("/?login"));
+                }
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/SecurityConfiguration.java
@@ -144,12 +144,9 @@ public class SecurityConfiguration {
                 boolean isAdmin = authentication.getAuthorities().stream().anyMatch(authority ->
                     authority.getAuthority().equals(ROLE_ADMIN)
                 );
+                String targetUrl = isAdmin ? "/ff4j-web-console/home" : "/?login";
 
-                if (isAdmin) {
-                    response.sendRedirect(response.encodeRedirectURL("/ff4j-web-console/home"));
-                } else {
-                    response.sendRedirect(response.encodeRedirectURL("/?login"));
-                }
+                response.sendRedirect(response.encodeRedirectURL(targetUrl));
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
@@ -4,6 +4,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
 import static org.springframework.http.ResponseEntity.ok;
 
 /**
@@ -11,6 +19,8 @@ import static org.springframework.http.ResponseEntity.ok;
  */
 @RestController
 public class RootController {
+
+    static final String TITLE = "Welcome to Feature Toggle API";
 
     /**
      * Root GET endpoint.
@@ -22,7 +32,21 @@ public class RootController {
      * @return Welcome message from the service.
      */
     @GetMapping
-    public ResponseEntity<String> welcome() {
-        return ok("Welcome to Feature Toggle API");
+    public ResponseEntity<String> welcome() throws URISyntaxException, IOException {
+        String response = TITLE;
+        URL url = getClass().getClassLoader().getResource("index.html");
+
+        if (url != null) {
+            Path path = Paths.get(url.toURI());
+            StringBuilder builder = new StringBuilder();
+
+            try (Stream<String> lines = Files.lines(path)) {
+                lines.forEach(builder::append);
+            }
+
+            response = builder.toString().replace("{title}", TITLE);
+        }
+
+        return ok(response);
     }
 }

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>{title}</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+  <h1>{title}</h1>
+  <div>
+    <a href="/login">Login form</a><br/>
+    <a href="/logout">Logout from current session</a>
+    <hr/>
+    <a href="/ff4j-web-console/home">FF4J Home</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Handle logout](https://tools.hmcts.net/jira/browse/RPE-498)

### Change description ###

Once you are logged in, there is no way to logout in case you want to access web admin and credentials used are not sufficient access level.

**NOTE** No matter how many different guides I went through with _simple_ solution as to how to redirect or do extra auth around login/logout, the setup in this PR is the only one that worked. And it was not mentioned anywhere specifically or by recommendation. I am explaining here the `EntryPoint` and `SuccessHandler` implementations

P.S. I am not using MVC as it is another set of crash course to spring boot and regardless any simple attempts (again following documentation, examples) - no success. This may as well be due to additional ff4j dispatcher with it's own mvc present

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
