### PR TITLE
Fix root controller

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/feature/controllers/GetWelcomeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/feature/controllers/GetWelcomeTest.java
@@ -28,6 +28,6 @@ public class GetWelcomeTest {
             .getResponse()
             .getContentAsString();
 
-        assertThat(response).contains(RootController.TITLE);
+        assertThat(response).contains("Welcome to Feature Toggle API");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
@@ -5,11 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 import static org.springframework.http.ResponseEntity.ok;
@@ -32,12 +31,12 @@ public class RootController {
      * @return Welcome message from the service.
      */
     @GetMapping
-    public ResponseEntity<String> welcome() throws URISyntaxException, IOException {
+    public ResponseEntity<String> welcome() throws IOException {
         String response = TITLE;
-        URL url = getClass().getClassLoader().getResource("index.html");
+        URL url = getClass().getResource("index.html");
 
         if (url != null) {
-            Path path = Paths.get(url.toURI());
+            Path path = FileSystems.getDefault().getPath(url.toString());
             StringBuilder builder = new StringBuilder();
 
             try (Stream<String> lines = Files.lines(path)) {

--- a/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/controllers/RootController.java
@@ -1,15 +1,13 @@
 package uk.gov.hmcts.reform.feature.controllers;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.stream.Stream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -18,8 +16,6 @@ import static org.springframework.http.ResponseEntity.ok;
  */
 @RestController
 public class RootController {
-
-    static final String TITLE = "Welcome to Feature Toggle API";
 
     /**
      * Root GET endpoint.
@@ -32,19 +28,10 @@ public class RootController {
      */
     @GetMapping
     public ResponseEntity<String> welcome() throws IOException {
-        String response = TITLE;
-        URL url = getClass().getResource("index.html");
+        InputStream in = getClass().getResourceAsStream("/index.html");
 
-        if (url != null) {
-            Path path = FileSystems.getDefault().getPath(url.toString());
-            StringBuilder builder = new StringBuilder();
-
-            try (Stream<String> lines = Files.lines(path)) {
-                lines.forEach(builder::append);
-            }
-
-            response = builder.toString().replace("{title}", TITLE);
-        }
+        String response = StreamUtils.copyToString(in, Charset.defaultCharset())
+            .replace("{title}", "Welcome to Feature Toggle API");
 
         return ok(response);
     }


### PR DESCRIPTION
### Change description ###

- Logout Filter invokes Root controller which causes application to throw `Request processing failed; nested exception is java.nio.file.FileSystemNotFoundException]`.

- FileSystemNotFoundException means the file system cannot be created automatically and we have not created it here.

- This is caused as we were using `Paths.get(url.toURI());` which relies on `ZipFileSystemProvider`. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```