### PR TITLE
Feature RPE-428: filter with idam client

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -17,6 +17,7 @@ print_help() {
   Available parameters:
     APPINSIGHTS                   Defaults to '00000000-0000-0000-0000-000000000000'
     DB_PASSWORD                   Defaults to 'password'
+    IDAM_URL                      Defaults to 'false' - use stub
   "
 }
 
@@ -28,6 +29,7 @@ FLYWAY_ENABLED=false
 # environment variables
 APPINSIGHTS="00000000-0000-0000-0000-000000000000"
 DB_PASSWORD="password"
+IDAM_URL="false"
 
 execute_script() {
   cd $(dirname "$0")/..
@@ -48,6 +50,7 @@ execute_script() {
 
   export APPINSIGHTS_INSTRUMENTATIONKEY=${APPINSIGHTS}
   export FEATURES_DB_PASSWORD=${DB_PASSWORD}
+  export IDAM_URL=${IDAM_URL}
 
   echo "Bringing up docker containers.."
 
@@ -69,6 +72,7 @@ while true ; do
       case "$2" in
         APPINSIGHTS=*) APPINSIGHTS="${2#*=}" ; shift 2 ;;
         DB_PASSWORD=*) DB_PASSWORD="${2#*=}" ; shift 2 ;;
+        IDAM_URL=*) IDAM_URL="${2#*=}" ; shift 2 ;;
         *) shift 2 ;;
       esac ;;
     *) execute_script ; break ;;

--- a/docker-compose-core.yml
+++ b/docker-compose-core.yml
@@ -19,6 +19,7 @@ services:
       - FEATURES_DB_CONN_OPTIONS
       - FEATURES_DB_USER_NAME
       - FEATURES_DB_PASSWORD
+      - IDAM_URL
       # these environment variables are used by java-logging library
       - ROOT_APPENDER
       - JSON_CONSOLE_PRETTY_PRINT

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,3 +1,4 @@
 vault_section = "preprod"
 capacity = "2"
 external_host_name = "www.featuretoggle.nonprod.platform.hmcts.net"
+idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,2 +1,3 @@
 vault_section = "preprod"
 external_host_name = "www.featuretoggle.demo.platform.hmcts.net"
+idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -65,6 +65,7 @@ module "feature-toggle-api" {
     FLYWAY_URL                  = "jdbc:postgresql://${module.feature-toggle-db.host_name}:${module.feature-toggle-db.postgresql_listen_port}/${module.feature-toggle-db.postgresql_database}${local.db_connection_options}"
     FLYWAY_USER                 = "${module.feature-toggle-db.user_name}"
     FLYWAY_PASSWORD             = "${module.feature-toggle-db.postgresql_password}"
+    IDAM_URL                    = "${var.idam_api_url}"
     TEST_ADMIN_USERNAME         = "${local.test_admin_user}"
     TEST_ADMIN_PASSWORD         = "${local.test_admin_password}"
     TEST_EDITOR_USERNAME        = "${local.test_editor_user}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -9,3 +9,11 @@ output "vaultName" {
 output "microserviceName" {
   value = "${var.component}"
 }
+
+output "idam_url_for_tests" {
+  value = "${var.idam_api_url}"
+}
+
+output "use_idam_testing_support" {
+  value = "${var.use_idam_testing_support}"
+}

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,1 +1,2 @@
 vault_section = "preprod"
+idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,3 +1,5 @@
 vault_section = "prod"
 capacity = "2"
 external_host_name = "www.featuretoggle.prod.platform.hmcts.net"
+idam_api_url = "https://prod-idamapi.reform.hmcts.net:3511"
+use_idam_testing_support = "false"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -52,3 +52,11 @@ variable "capacity" {
 variable "external_host_name" {
   default = "www.featuretoggle.sprod.platform.hmcts.net"
 }
+
+variable "idam_api_url" {
+  default = "http://idam-api-idam-saat.service.core-compute-saat.internal"
+}
+
+variable "use_idam_testing_support" {
+  default = "true"
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/feature/ApplicationTests.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/feature/ApplicationTests.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.feature.authorisation.IdamUserAuthoriser;
+import uk.gov.hmcts.reform.feature.authorisation.IdamUserAuthoriserClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,9 +25,16 @@ public class ApplicationTests {
     @Autowired
     private UserDetailsService userDetailsService;
 
+    @Autowired
+    private IdamUserAuthoriser idamUserAuthoriser;
+
     @Test
     public void should_load_in_memory_user_details_manager_when_flyway_is_disabled() {
         assertThat(userDetailsService).isInstanceOf(InMemoryUserDetailsManager.class);
     }
 
+    @Test
+    public void should_load_stubbed_idam_user_authoriser() {
+        assertThat(idamUserAuthoriser).isNotInstanceOf(IdamUserAuthoriserClient.class);
+    }
 }

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -1,3 +1,5 @@
+idam.url=false
+
 management.endpoints.web.base-path=/
 
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/src/main/java/uk/gov/hmcts/reform/feature/authorisation/IdamUserAuthoriser.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/authorisation/IdamUserAuthoriser.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.feature.authorisation;
+
+import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
+
+public interface IdamUserAuthoriser {
+
+    UserTokenDetails getUserDetails(String authHeader);
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/authorisation/IdamUserAuthoriserClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/authorisation/IdamUserAuthoriserClient.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.feature.authorisation;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+public class IdamUserAuthoriserClient implements IdamUserAuthoriser {
+
+    private final String idamUrl;
+    private final RestTemplate restTemplate;
+
+    public IdamUserAuthoriserClient(String idamUrl) {
+        this.idamUrl = idamUrl;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Override
+    public UserTokenDetails getUserDetails(String authHeader) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(AUTHORIZATION, authHeader);
+
+        return restTemplate.exchange(
+            idamUrl + "/details",
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            UserTokenDetails.class
+        ).getBody();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/config/AuthenticationProviderConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/config/AuthenticationProviderConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.feature.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +11,8 @@ import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import uk.gov.hmcts.reform.feature.authorisation.IdamUserAuthoriser;
+import uk.gov.hmcts.reform.feature.authorisation.IdamUserAuthoriserClient;
 
 import javax.sql.DataSource;
 
@@ -37,6 +40,18 @@ public class AuthenticationProviderConfiguration {
     @ConditionalOnProperty(prefix = "flyway", name = "enabled", havingValue = "false")
     public UserDetailsService inMemoryUserDetailsService() {
         return new InMemoryUserDetailsManager();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "idam", name = "url")
+    public IdamUserAuthoriser idamUserAuthoriser(@Value("${idam.url}") String idamUrl) {
+        return new IdamUserAuthoriserClient(idamUrl);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "idam", name = "url", havingValue = "false", matchIfMissing = true)
+    public IdamUserAuthoriser idamUserAuthoriserStub() {
+        return (String authHeader) -> null;
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.feature.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserTokenDetails {
+
+    public final String id;
+
+    public final String email;
+
+    public final Set<String> roles;
+
+    public UserTokenDetails(
+        @JsonProperty("id") String id,
+        @JsonProperty("email") String email,
+        @JsonProperty("roles") Set<String> roles
+    ) {
+        this.id = id;
+        this.email = email;
+        this.roles = roles;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.feature.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import uk.gov.hmcts.reform.feature.authorisation.IdamUserAuthoriser;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpMethod.GET;
+
+public class IdamUserAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    @Autowired
+    private IdamUserAuthoriser idamAuthoriser;
+
+    public IdamUserAuthenticationFilter(String pattern) {
+        super(new AntPathRequestMatcher(pattern, GET.name()));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) throws AuthenticationException, IOException, ServletException {
+        return null;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,9 @@ management:
     web:
       base-path: /
 
+idam:
+  url: ${IDAM_URL}
+
 info:
    app:
       name: Feature Toggle API

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+idam.url=false


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Private Beta Users](https://tools.hmcts.net/jira/browse/RPE-428)

### Change description ###

Initial setup of auth filter as a helper to figure out roles of a user provided by authorisation header. This build is bare minimum with components will be used in future development.

- [x] initial filter with idam client for user details
- [ ] implement filter without failing the process and always falling back to null (or current) authorisation
- [ ] stick filter in security config and write bunch of tests
- [ ] cache idam calls

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
