### PR TITLE
Feature: filter with jwt parser

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
@@ -8,9 +8,9 @@ import java.util.stream.Collectors;
 
 public class UserTokenDetails {
 
-    public final String id;
+    private final String id;
 
-    public final List<? extends GrantedAuthority> roles;
+    private final List<? extends GrantedAuthority> roles;
 
     public UserTokenDetails(String id, List<String> roles) {
         this.id = id;
@@ -18,5 +18,13 @@ public class UserTokenDetails {
             .stream()
             .map(SimpleGrantedAuthority::new)
             .collect(Collectors.toList());
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public List<? extends GrantedAuthority> getRoles() {
+        return roles;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.feature.model;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserTokenDetails {
+
+    public final String id;
+
+    public final List<? extends GrantedAuthority> roles;
+
+    public UserTokenDetails(String id, List<String> roles) {
+        this.id = id;
+        this.roles = roles
+            .stream()
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/model/UserTokenDetails.java
@@ -10,7 +10,7 @@ public class UserTokenDetails {
 
     private final String id;
 
-    private final List<? extends GrantedAuthority> roles;
+    private final List<GrantedAuthority> roles;
 
     public UserTokenDetails(String id, List<String> roles) {
         this.id = id;
@@ -24,7 +24,7 @@ public class UserTokenDetails {
         return id;
     }
 
-    public List<? extends GrantedAuthority> getRoles() {
+    public List<GrantedAuthority> getRoles() {
         return roles;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
@@ -47,7 +47,10 @@ public class IdamUserAuthenticationFilter extends AbstractAuthenticationProcessi
     private Authentication parseUserTokenDetails(String key, UserTokenDetails userTokenDetails) {
         UserDetails details = User.withUsername("idam-user-" + userTokenDetails.id)
             .password("")
-            .roles(Roles.USER)
+            .roles(Roles.USER) // default built-in role for any user
+            // spring security clashes all roles and authorities into one
+            // `userTokenDetails.roles` come back from idam and can be in any `authority` format
+            // hence assigning as authorities for spring security to understand access levels correctly
             .authorities(userTokenDetails.roles)
             .build();
 

--- a/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.feature.security;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.intercept.RunAsUserToken;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.springframework.http.HttpMethod.GET;
+
+public class IdamUserAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    public IdamUserAuthenticationFilter(String pattern) {
+        super(new AntPathRequestMatcher(pattern, GET.name()));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) throws AuthenticationException, IOException, ServletException {
+        String authorisationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorisationHeader != null) {
+            UserTokenDetails userTokenDetails = null;// todo parse jwt
+
+            if (userTokenDetails != null) {
+                return parseUserTokenDetails(authorisationHeader, userTokenDetails);
+            }
+        }
+
+        // passing current auth in case some other authentication happened
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private Authentication parseUserTokenDetails(String key, UserTokenDetails userTokenDetails) {
+        UserDetails details = User.withUsername("idam-user-" + userTokenDetails.id)
+            .password("")
+            .roles(Roles.USER)
+            .authorities(userTokenDetails.roles)
+            .build();
+
+        return new RunAsUserToken(
+            key,
+            details,
+            details.getPassword(),
+            details.getAuthorities(),
+            AnonymousAuthenticationToken.class
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
@@ -25,10 +25,12 @@ import static org.springframework.http.HttpMethod.GET;
 
 public class IdamUserAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
-    private JwtParser parser;
+    private final JwtParser parser;
 
-    public IdamUserAuthenticationFilter(String pattern) {
+    public IdamUserAuthenticationFilter(String pattern, JwtParser parser) {
         super(new AntPathRequestMatcher(pattern, GET.name()));
+
+        this.parser = parser;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilter.java
@@ -45,13 +45,13 @@ public class IdamUserAuthenticationFilter extends AbstractAuthenticationProcessi
     }
 
     private Authentication parseUserTokenDetails(String key, UserTokenDetails userTokenDetails) {
-        UserDetails details = User.withUsername("idam-user-" + userTokenDetails.id)
+        UserDetails details = User.withUsername("idam-user-" + userTokenDetails.getId())
             .password("")
             .roles(Roles.USER) // default built-in role for any user
             // spring security clashes all roles and authorities into one
             // `userTokenDetails.roles` come back from idam and can be in any `authority` format
             // hence assigning as authorities for spring security to understand access levels correctly
-            .authorities(userTokenDetails.roles)
+            .authorities(userTokenDetails.getRoles())
             .build();
 
         return new RunAsUserToken(

--- a/src/main/java/uk/gov/hmcts/reform/feature/service/JwtParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/feature/service/JwtParser.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.feature.service;
+
+import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
+
+public interface JwtParser {
+
+    UserTokenDetails parse(String jwtToken);
+}

--- a/src/test/java/uk/gov/hmcts/reform/feature/model/UserTokenDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/feature/model/UserTokenDetailsTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.feature.model;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserTokenDetailsTest {
+
+    @Test
+    public void should_create_model_with_appropriate_list_of_grant_authorities() {
+        // having
+        List<String> idamRoles = ImmutableList.of("beta", "test", "user");
+
+        // when
+        UserTokenDetails details = new UserTokenDetails("ID", idamRoles);
+
+        // then
+        assertThat(details.getRoles()).hasOnlyElementsOfType(GrantedAuthority.class);
+        assertThat(details.getRoles()).extracting("authority").hasSameElementsAs(idamRoles);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilterTest.java
@@ -13,12 +13,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.util.ReflectionUtils;
 import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
 import uk.gov.hmcts.reform.feature.service.JwtParser;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -42,10 +40,7 @@ public class IdamUserAuthenticationFilterTest {
 
     @Before
     public void setUp() {
-        filter = new IdamUserAuthenticationFilter("/**");
-        Field field = ReflectionUtils.findField(filter.getClass(), "parser");
-        ReflectionUtils.makeAccessible(field);
-        ReflectionUtils.setField(field, filter, parser);
+        filter = new IdamUserAuthenticationFilter("/**", parser);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/feature/security/IdamUserAuthenticationFilterTest.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.reform.feature.security;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.intercept.RunAsUserToken;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.util.ReflectionUtils;
+import uk.gov.hmcts.reform.feature.model.UserTokenDetails;
+import uk.gov.hmcts.reform.feature.service.JwtParser;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdamUserAuthenticationFilterTest {
+
+    @Mock
+    private JwtParser parser;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private IdamUserAuthenticationFilter filter;
+
+    @Before
+    public void setUp() {
+        filter = new IdamUserAuthenticationFilter("/**");
+        Field field = ReflectionUtils.findField(filter.getClass(), "parser");
+        ReflectionUtils.makeAccessible(field);
+        ReflectionUtils.setField(field, filter, parser);
+    }
+
+    @Test
+    public void should_return_authorisation_from_context_when_no_header_passed() throws IOException, ServletException {
+        // given
+        Authentication anonymous = getAnonymous();
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+
+        // when
+        Authentication filteredAuth = filter.attemptAuthentication(request, response);
+
+        // then
+        assertThat(filteredAuth).isEqualToComparingFieldByFieldRecursively(anonymous);
+    }
+
+    @Test
+    public void should_return_authorisation_from_context_when_jwt_parser_returns_null()
+        throws IOException, ServletException {
+        // given
+        Authentication anonymous = getAnonymous();
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+
+        // and
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("value");
+
+        // when
+        Authentication filteredAuth = filter.attemptAuthentication(request, response);
+
+        // then
+        assertThat(filteredAuth).isEqualToComparingFieldByFieldRecursively(anonymous);
+    }
+
+    @Test
+    public void should_return_run_as_user_token_when_jwt_parser_returns_user_details()
+        throws IOException, ServletException {
+        // given
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("some_value");
+        given(parser.parse("some_value")).willReturn(new UserTokenDetails("id", ImmutableList.of("test")));
+
+        // when
+        Authentication filteredAuth = filter.attemptAuthentication(request, response);
+
+        // then
+        assertThat(filteredAuth).isInstanceOf(RunAsUserToken.class);
+        assertThat(filteredAuth.getAuthorities())
+            .extracting("authority")
+            .hasSameElementsAs(ImmutableList.of("test", "ROLE_" + Roles.USER));
+    }
+
+    private Authentication getAnonymous() {
+        return new AnonymousAuthenticationToken(
+            "anonymous",
+            User.withUsername("anonymous").password("").roles(Roles.USER).build(),
+            ImmutableList.of(new SimpleGrantedAuthority(Roles.USER))
+        );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Private Beta Users](https://tools.hmcts.net/jira/browse/RPE-428)

### Change description ###

Initial setup of auth filter as a helper to figure out roles of a user provided by authorisation header. This build is bare minimum with components will be used in future development.

- [x] filter implementation with placeholder for jwt token parser
- [ ] implement jwt token parser
- [ ] stick filter in security config and write bunch of tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
