### PR TITLE
Excluded d3js dependency as it is not used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ def versions = [
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+configurations.all {
+  exclude group: "org.webjars", module: "d3js"
+}
+
 sourceSets {
   functionalTest {
     java {


### PR DESCRIPTION
### Change description ###

- Excluded d3js dependency as it has vulnerability reported by OWASP Dependency check plugin.
https://nvd.nist.gov/vuln/detail/CVE-2017-16044

- Tested locally and FF4J admin page loads fine.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```