### PR TITLE
Refactor smoke tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
@@ -66,9 +66,4 @@ public abstract class BaseTest {
             .then()
             .statusCode(201);
     }
-
-    protected void deleteAllFeatures() {
-        requestSpecification()
-            .delete("/api/ff4j/store/clear");
-    }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/BaseTest.java
@@ -11,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 import java.io.IOException;
 
@@ -22,7 +21,7 @@ import java.io.IOException;
 public abstract class BaseTest {
 
     @Value("${test-url}")
-    private String testUrl;
+    protected String testUrl;
 
     @Value("${test-admin-user}")
     protected String testAdminUser;
@@ -35,8 +34,6 @@ public abstract class BaseTest {
 
     @Value("${test-editor-password}")
     protected String testEditorPassword;
-
-    private static final String SYNTHETIC_SOURCE_HEADER_VALUE = "Feature Toggle Smoke Test";
 
     protected static final String FF4J_STORE_FEATURES_URL = "api/ff4j/store/features/";
 
@@ -52,8 +49,7 @@ public abstract class BaseTest {
             .auth().preemptive().basic(testAdminUser, testAdminPassword)
             .relaxedHTTPSValidation()
             .baseUri(this.testUrl)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, SYNTHETIC_SOURCE_HEADER_VALUE);
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
     }
 
     protected void createFeatureToggle(String featureUuid, String createRequestBody) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/UnauthorizedAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/UnauthorizedAccessTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.feature;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpStatus.OK;
@@ -10,7 +8,6 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 public class UnauthorizedAccessTest extends BaseTest {
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_restrict_anonymous_access_to_api_ff4j() {
         requestSpecification()
@@ -20,7 +17,6 @@ public class UnauthorizedAccessTest extends BaseTest {
             .statusCode(UNAUTHORIZED.value());
     }
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_restrict_anonymous_access_to_ff4j_web_console() {
         requestSpecification()
@@ -32,7 +28,6 @@ public class UnauthorizedAccessTest extends BaseTest {
             .body("html.head.title", equalTo("Login Page"));
     }
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_restrict_access_for_user_to_access_ff4j_web_console() {
         requestSpecification()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/ChangeFeatureToggleTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/ChangeFeatureToggleTest.java
@@ -1,16 +1,13 @@
 package uk.gov.hmcts.reform.feature.api;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.feature.BaseTest;
-import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import java.io.IOException;
 import java.util.UUID;
 
 public class ChangeFeatureToggleTest extends BaseTest {
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_successfully_enable_feature_toggle_in_feature_store() throws IOException {
         //Feature name should be unique in the feature store
@@ -32,7 +29,6 @@ public class ChangeFeatureToggleTest extends BaseTest {
             .delete(FF4J_STORE_FEATURES_URL + featureUuid);
     }
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_successfully_disable_feature_toggle_in_feature_store() throws IOException {
         //Feature name should be unique in the feature store

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/CreateFeatureToggleTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/CreateFeatureToggleTest.java
@@ -1,16 +1,13 @@
 package uk.gov.hmcts.reform.feature.api;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.feature.BaseTest;
-import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import java.io.IOException;
 import java.util.UUID;
 
 public class CreateFeatureToggleTest extends BaseTest {
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_successfully_create_feature_toggle_in_feature_store() throws IOException {
         //Feature name should be unique in the feature store

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/FeatureStoreTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/FeatureStoreTest.java
@@ -13,10 +13,6 @@ public class FeatureStoreTest extends BaseTest {
 
     @Test
     public void should_return_feature_store_details() throws IOException {
-        //Delete all features in the feature store else the last one is returned by default
-        //Functional tests are not executed on prod slot so should be safe to do this.
-        deleteAllFeatures();
-
         String featureUuid1 = UUID.randomUUID().toString();
         String featureUuid2 = UUID.randomUUID().toString();
 
@@ -27,7 +23,8 @@ public class FeatureStoreTest extends BaseTest {
             .get("/api/ff4j/store").jsonPath();
 
         assertThat(jsonPath.getString("type")).isEqualTo("org.ff4j.audit.proxy.FeatureStoreAuditProxy");
-        assertThat(jsonPath.getInt("numberOfFeatures")).isEqualTo(2);
+        //There might be other features in feature store but there should be at least 2 as we are creating it
+        assertThat(jsonPath.getInt("numberOfFeatures")).isGreaterThanOrEqualTo(2);
         assertThat(jsonPath.getString("cache")).isNull();
         assertThat(jsonPath.getList("features")).containsExactly(featureUuid1, featureUuid2);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/GetFeatureToggleTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/GetFeatureToggleTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.feature.api;
 
 import io.restassured.path.json.JsonPath;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import uk.gov.hmcts.reform.feature.BaseTest;
 
@@ -41,18 +40,5 @@ public class GetFeatureToggleTest extends BaseTest {
         assertThat(jsonPath.getInt("status")).isEqualTo(404);
         assertThat(jsonPath.getString("error")).isEqualTo("Not Found");
         assertThat(jsonPath.getString("exception")).contains("FeatureNotFoundException");
-    }
-
-    @Test
-    public void should_throw_feature_id_blank_exception_when_feature_id_is_blank() {
-
-        //Delete all features in the feature store else the last one is returned by default
-        //Functional tests are not executed on prod slot so should be safe to do this.
-        deleteAllFeatures();
-
-        requestSpecification()
-            .get(FF4J_STORE_FEATURES_URL)
-            .then()
-            .body("$", Matchers.empty());
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/RetrieveFeatureToggleSmokeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/RetrieveFeatureToggleSmokeTest.java
@@ -1,20 +1,29 @@
 package uk.gov.hmcts.reform.feature.api;
 
+import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.feature.BaseTest;
 import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
-
-import java.io.IOException;
+import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 public class RetrieveFeatureToggleSmokeTest extends BaseTest {
 
+    private static final String SYNTHETIC_SOURCE_HEADER_VALUE = "Feature Toggle Smoke Test";
+
     @Category(SmokeTestCategory.class)
     @Test
-    public void should_return_all_feature_toggles_from_feature_store() throws IOException {
-        Response response = requestSpecification()
+    public void should_return_all_feature_toggles_from_feature_store() {
+        Response response = RestAssured
+            .given()
+            .baseUri(this.testUrl)
+            .relaxedHTTPSValidation()
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, SYNTHETIC_SOURCE_HEADER_VALUE)
             .get("/api/ff4j/store/features");
 
         Assertions.assertThat(response.getStatusCode()).isEqualTo(200);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/RetrieveFeatureToggleSmokeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/api/RetrieveFeatureToggleSmokeTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.feature.api;
+
+import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import uk.gov.hmcts.reform.feature.BaseTest;
+import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
+
+import java.io.IOException;
+
+public class RetrieveFeatureToggleSmokeTest extends BaseTest {
+
+    @Category(SmokeTestCategory.class)
+    @Test
+    public void should_return_all_feature_toggles_from_feature_store() throws IOException {
+        Response response = requestSpecification()
+            .get("/api/ff4j/store/features");
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(200);
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/AdminAccessTest.java
@@ -4,9 +4,7 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Cookies;
 import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.feature.BaseTest;
-import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -16,7 +14,6 @@ import static org.springframework.http.HttpStatus.OK;
 
 public class AdminAccessTest extends BaseTest {
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_not_allow_access_for_non_admin_user() {
         RequestSpecification specification = requestSpecification();
@@ -42,7 +39,6 @@ public class AdminAccessTest extends BaseTest {
             .body("html.head.title", equalTo("Error"));
     }
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_verify_login_logout_journey() {
         RequestSpecification specification = requestSpecification();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/LoginTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/feature/webconsole/LoginTest.java
@@ -3,9 +3,7 @@ package uk.gov.hmcts.reform.feature.webconsole;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import uk.gov.hmcts.reform.feature.BaseTest;
-import uk.gov.hmcts.reform.feature.categories.SmokeTestCategory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.LOCATION;
@@ -13,7 +11,6 @@ import static org.springframework.http.HttpStatus.FOUND;
 
 public class LoginTest extends BaseTest {
 
-    @Category(SmokeTestCategory.class)
     @Test
     public void should_allow_user_to_login_and_redirected_to_home_page() {
         RequestSpecification specification = requestSpecification();


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-629

### Change description ###

-  Currently smoke tests fail on production slot as it looks like some with RestAssured authentication where it works fine with staging slot but fails to authenticate and returns 401 intermittently.

- As discussed with the team refactored the test cases such that as part of smoke tests we would be only fetching feature toggles and rest will be executed as part of functional tests.

- Also removed `deleteAllFeatures` which is invalid test case.

- Tested on Demo environment with 7 consecutive build successfully deployed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```