### PR TITLE
[PREVIEW] Read test secrets from Azure Key Vault instead of Hashicorp Vault

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -22,6 +22,10 @@ locals {
   nonPreviewVaultName    = "${var.product}-ft-api-${var.env}"
   vaultName              = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
+  # URI of vault that stores long-term secrets. It's the app's own Key Vault, except for (s)preview,
+  # where vaults are short-lived and can only store secrets generated during deployment
+  permanent_vault_uri    = "https://${var.raw_product}-ft-api-${local.local_env}.vault.azure.net/"
+
   cmcPreviewVaultName = "cmc-aat"
   cmcNonPreviewVaultName = "cmc-${var.env}"
   cmcVaultName = "${(var.env == "preview" || var.env == "spreview") ? local.cmcPreviewVaultName : local.cmcNonPreviewVaultName}"
@@ -30,17 +34,17 @@ locals {
   divorcePreviewVaultName = "div-aat"
   divorceNonPreviewVaultName = "div-${var.env}"
   divorceVaultName = "${(var.env == "preview" || var.env == "spreview") ? local.divorcePreviewVaultName : local.divorceNonPreviewVaultName}"
-  
+
   probatePreviewVaultName = "probate-aat"
   probateNonPreviewVaultName = "probate-${var.env}"
   probateVaultName = "${(var.env == "preview" || var.env == "spreview") ? local.probatePreviewVaultName : local.probateNonPreviewVaultName}"
 
   db_connection_options  = "?ssl=true"
 
-  test_admin_user        = "${data.vault_generic_secret.test-admin-user.data["value"]}"
-  test_admin_password    = "${data.vault_generic_secret.test-admin-password.data["value"]}"
-  test_editor_user       = "${data.vault_generic_secret.test-editor-user.data["value"]}"
-  test_editor_password   = "${data.vault_generic_secret.test-editor-password.data["value"]}"
+  test_admin_user        = "${data.azurerm_key_vault_secret.source-test-admin-user.value}"
+  test_admin_password    = "${data.azurerm_key_vault_secret.source-test-admin-password.value}"
+  test_editor_user       = "${data.azurerm_key_vault_secret.source-test-editor-user.value}"
+  test_editor_password   = "${data.azurerm_key_vault_secret.source-test-editor-password.value}"
 
   sku_size = "${var.env == "prod" || var.env == "sprod" || var.env == "aat" ? "I2" : "I1"}"
 }
@@ -96,7 +100,7 @@ module "feature-toggle-api" {
     DIVORCE_ADMIN_PASSWORD      = "${data.azurerm_key_vault_secret.divorce_admin_password.value}"
     DIVORCE_EDITOR_USERNAME     = "${data.azurerm_key_vault_secret.divorce_editor_username.value}"
     DIVORCE_EDITOR_PASSWORD     = "${data.azurerm_key_vault_secret.divorce_editor_password.value}"
-    
+
     PROBATE_ADMIN_USERNAME      = "${data.azurerm_key_vault_secret.probate_admin_username.value}"
     PROBATE_ADMIN_PASSWORD      = "${data.azurerm_key_vault_secret.probate_admin_password.value}"
     PROBATE_EDITOR_USERNAME     = "${data.azurerm_key_vault_secret.probate_editor_username.value}"

--- a/infrastructure/test_config.tf
+++ b/infrastructure/test_config.tf
@@ -1,17 +1,25 @@
-data "vault_generic_secret" "test-admin-user" {
-  path = "secret/${var.vault_section}/cc/ff4j/webconsole/test-admin-user"
+# Secrets for tests are stored in permanent (long-lived) Azure Key Vault instances.
+# With the exception of (s)preview all Vault instances are long-lived. For preview, however,
+# test secrets (not created during deployment) need to be copied over from a permanent vault -
+# that's what the code below does.
+data "azurerm_key_vault_secret" "source-test-admin-user" {
+  name = "test-admin-user"
+  vault_uri = "${local.permanent_vault_uri}"
 }
 
-data "vault_generic_secret" "test-admin-password" {
-  path = "secret/${var.vault_section}/cc/ff4j/webconsole/test-admin-password"
+data "azurerm_key_vault_secret" "source-test-admin-password" {
+  name = "test-admin-password"
+  vault_uri = "${local.permanent_vault_uri}"
 }
 
-data "vault_generic_secret" "test-editor-user" {
-  path = "secret/${var.vault_section}/cc/ff4j/webconsole/test-editor-user"
+data "azurerm_key_vault_secret" "source-test-editor-user" {
+  name = "test-editor-user"
+  vault_uri = "${local.permanent_vault_uri}"
 }
 
-data "vault_generic_secret" "test-editor-password" {
-  path = "secret/${var.vault_section}/cc/ff4j/webconsole/test-editor-password"
+data "azurerm_key_vault_secret" "source-test-editor-password" {
+  name = "test-editor-password"
+  vault_uri = "${local.permanent_vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-admin-user" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -2,6 +2,10 @@ variable "product" {
   type    = "string"
 }
 
+variable "raw_product" {
+  default = "rpe"
+}
+
 variable "component" {
   type = "string"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Read test secrets from Azure Key Vault instead of Hashicorp Vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
