### PR TITLE
[PREVIEW] Remove (Hashicorp) vault provider config from infrastructure code

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,9 +1,5 @@
 provider "azurerm" {}
 
-provider "vault" {
-  address = "https://vault.reform.hmcts.net:6200"
-}
-
 # Make sure the resource group exists
 resource "azurerm_resource_group" "rg" {
   name     = "${var.product}-${var.component}-${var.env}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Remove (Hashicorp) vault provider config from infrastructure code. We don't use Hashicorp Vault anymore.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
