### PR TITLE
Revert "Migrating to latest charts, javalogging version"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ version = '0.0.1'
 def versions = [
   ff4j            : '1.7.1',
   logback         : '1.2.3',
-  reformLogging   : '5.0.1',
+  reformLogging   : '2.2.1',
   springBoot      : springBoot.class.package.implementationVersion,
   springHystrix   : '1.4.6.RELEASE',
   springfoxSwagger: '2.9.2'
@@ -168,7 +168,6 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
-  compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.3'
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
   compile group: 'ch.qos.logback', name: 'logback-core', version: versions.logback

--- a/charts/rpe-feature-toggle-api/requirements.yaml
+++ b/charts/rpe-feature-toggle-api/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: java
-    version: ~1.0.3
+    version: '>=0.0.13'
     repository: '@hmcts'
   - name: postgresql
     version: ~3.1.0

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -63,13 +63,4 @@
     <cve>CVE-2018-19361</cve>
     <cve>CVE-2018-19362</cve>
   </suppress>
-
-  <suppress>
-    <notes><![CDATA[
-    Suppressing as it seems a false positive as per https://github.com/jeremylong/DependencyCheck/issues/1573
-    ]]></notes>
-    <gav regex="true">^io\.netty:netty-tcnative-boringssl-static:.*</gav>
-    <cve>CVE-2014-3488</cve>
-    <cve>CVE-2015-2156</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
This reverts commit 589752797962b58f59d73ac401d3fce886ec8702.


Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
