### PR TITLE
Various tweaks for HMCTS Demo preparation with CMC stack

### DIFF
--- a/charts/rpe-feature-toggle-api/Chart.yaml
+++ b/charts/rpe-feature-toggle-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the feature-toggle-api (https://github.com/hmcts/feature-toggle-api)
 name: rpe-feature-toggle-api
-version: 2.0.1
+version: 3.0.0
 icon: https://github.com/hmcts/rpe-feature-toggle-api/raw/master/charts/rpe-feature-toggle-api/images/icons8-java-50.png
 keywords:
   - feature-toggle-api

--- a/charts/rpe-feature-toggle-api/templates/importer.yaml
+++ b/charts/rpe-feature-toggle-api/templates/importer.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.importer.kvSecretRef }}
       volumes:
         - name: kvcreds
           flexVolume:
@@ -36,24 +37,33 @@ spec:
               resourcegroup: {{ include "importer.resourcegroup" . | quote }}
               keyvaultobjectnames: "admin-username-cmc;admin-password-cmc"
               keyvaultobjecttypes: "secret;secret" # OPTIONS: secret, key, cert
+      {{- end }}
       containers:
         - name: {{ template "hmcts.releaseName" . }}-importer
           image: {{ .Values.importer.oneoff.image }} 
           imagePullPolicy: {{ .Values.importer.oneoff.imagePullPolicy }}
           command: ["sh", "-c", "{{ .Values.importer.oneoff.command }}"]
+          {{- if .Values.importer.kvSecretRef }}
           volumeMounts:
           - name: kvcreds
             mountPath: /kvmnt
             readOnly: true
+          {{- end }}
           env:
+          {{- if .Values.importer.kvSecretRef }}
           - name: IMPORTER_CREDS_MOUNT
             value: "/kvmnt"
+          {{- end }}
           - name: FEATURE_TOGGLE_API_URL
-            value: "http://{{ template "hmcts.releaseName" . }}/api/ff4j/store/features/"
+            value: "{{ .Values.importer.apiUrl }}"
           - name: PERMISSIONS
             value: "{{ .Values.importer.oneoff.permissions }}"
           - name: VERBOSE
             value: "true"
+          - name: ADMIN_USERNAME
+            value: "{{ .Values.importer.adminUsername }}"  # kvcreds takes priority
+          - name: ADMIN_PASSWORD
+            value: "{{ .Values.importer.adminPassword }}"  # kvcreds takes priority
       restartPolicy: Never   # Move to "OnFailure" after first charts are done 
 {{- end }}
 {{- if .Values.importer.cron.enabled }}
@@ -80,6 +90,7 @@ spec:
           labels:
             app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}-importer
         spec:
+          {{- if .Values.importer.kvSecretRef }}
           volumes:
             - name: kvcreds
               flexVolume:
@@ -94,24 +105,33 @@ spec:
                   resourcegroup: {{ include "importer.resourcegroup" . | quote }}
                   keyvaultobjectnames: "admin-username-cmc;admin-password-cmc"
                   keyvaultobjecttypes: "secret;secret" # OPTIONS: secret, key, cert
+          {{- end }}
           containers:
           - image: {{ .Values.importer.cron.image }}
             name: {{ template "hmcts.releaseName" . }}-importer
             imagePullPolicy: {{ .Values.importer.cron.imagePullPolicy }}
             command: ["sh", "-c", "{{ .Values.importer.cron.command }}"]
+            {{- if .Values.importer.kvSecretRef }}
             volumeMounts:
             - name: kvcreds
               mountPath: /kvmnt
               readOnly: true
+            {{- end }}
             env:
+              {{- if .Values.importer.kvSecretRef }}
               - name: IMPORTER_CREDS_MOUNT
                 value: "/kvmnt"
+              {{- end }}
               - name: FEATURE_TOGGLE_API_URL
                 value: "http://{{ template "hmcts.releaseName" . }}/api/ff4j/store/features/"
               - name: PERMISSIONS
                 value: "{{ .Values.importer.cron.permissions }}"
               - name: VERBOSE
                 value: "true"
+              - name: ADMIN_USERNAME
+                value: "{{ .Values.importer.adminUsername }}"  # kvcreds takes priority
+              - name: ADMIN_PASSWORD
+                value: "{{ .Values.importer.adminPassword }}"  # kvcreds takes priority
           restartPolicy: Never
       backoffLimit: 4
 {{- end }}

--- a/charts/rpe-feature-toggle-api/templates/importer.yaml
+++ b/charts/rpe-feature-toggle-api/templates/importer.yaml
@@ -53,6 +53,11 @@ spec:
           {{- if .Values.importer.kvSecretRef }}
           - name: IMPORTER_CREDS_MOUNT
             value: "/kvmnt"
+          {{- else }}
+          - name: ADMIN_USERNAME
+            value: "{{ .Values.importer.adminUsername }}"
+          - name: ADMIN_PASSWORD
+            value: "{{ .Values.importer.adminPassword }}"
           {{- end }}
           - name: FEATURE_TOGGLE_API_URL
             value: "{{ .Values.importer.apiUrl }}"
@@ -60,10 +65,6 @@ spec:
             value: "{{ .Values.importer.oneoff.permissions }}"
           - name: VERBOSE
             value: "true"
-          - name: ADMIN_USERNAME
-            value: "{{ .Values.importer.adminUsername }}"  # kvcreds takes priority
-          - name: ADMIN_PASSWORD
-            value: "{{ .Values.importer.adminPassword }}"  # kvcreds takes priority
       restartPolicy: Never   # Move to "OnFailure" after first charts are done 
 {{- end }}
 {{- if .Values.importer.cron.enabled }}

--- a/charts/rpe-feature-toggle-api/values.preview.template.yaml
+++ b/charts/rpe-feature-toggle-api/values.preview.template.yaml
@@ -1,6 +1,9 @@
 postgresql:
   enabled: true
   
+importer:
+  kvSecretRef: kvcreds
+  
 java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/rpe-feature-toggle-api/values.yaml
+++ b/charts/rpe-feature-toggle-api/values.yaml
@@ -1,17 +1,17 @@
 importer:
-  kvSecretRef: kvcreds
+  apiUrl: http://rpe-feature-toggle-api/api/ff4j/store/features/
   cron:
     enabled: false
     schedule: '*/5 * * * *'
     concurrencyPolicy: Forbid
     image: hmcts.azurecr.io/hmcts/feature-toggle-importer:db1fs8  # pin to specific tag
     command: echo FEATURE_TOGGLE_API_URL=${FEATURE_TOGGLE_API_URL}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
   oneoff:
     enabled: false
     image: hmcts.azurecr.io/hmcts/feature-toggle-importer:db1fs8  # pin to specific tag
     command: echo FEATURE_TOGGLE_API_URL=${FEATURE_TOGGLE_API_URL}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
 
 java:
   image: hmcts.azurecr.io/hmcts/rpe-feature-toggle-api:latest


### PR DESCRIPTION

### Change description ###

Make more flexbile - removing kvcreds mount by default (not used in HMCTS Demo) and allowing admin creds to be passed as vars.

Also changed feature toggle api to be a provided value instead of derived from release name - this wasn't working as expected and with the Java chart mix would have meant defining the same value twice:

```
rpe-feature-toggle-api:
    releaseNameOverride: my-release-ftrtgl
    java:
      releaseNameOverride: my-release-ftrtgl
```

Now defined as:
```
rpe-feature-toggle-api:
    importer:
      apiUrl: http://my-release-ftrtgl/api/ff4j/store/features/
    java:
      releaseNameOverride: my-release-ftrtgl
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (bumped major - kvcreds not mounted by default)
[ ] No
```
