### PR TITLE
[WIP] cleanup of feature_toggle api logs

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,3 +1,4 @@
 vault_section      = "preprod"
 capacity           = "2"
 external_host_name = "www.featuretoggle.nonprod.platform.hmcts.net"
+enable_ase         = true

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,2 +1,3 @@
 vault_section      = "preprod"
 external_host_name = "www.featuretoggle.demo.platform.hmcts.net"
+enable_ase         = true

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -38,6 +38,7 @@ module "feature-toggle-db" {
 
 module "feature-toggle-api" {
   source               = "git@github.com:hmcts/cnp-module-webapp?ref=master"
+  enable_ase           = "${var.enable_ase}"
   product              = "${var.product}-${var.component}"
   location             = "${var.location_app}"
   env                  = "${var.env}"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,3 +1,4 @@
 vault_section      = "prod"
 capacity           = "2"
 external_host_name = "www.featuretoggle.prod.platform.hmcts.net"
+enable_ase         = true

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -60,3 +60,7 @@ variable "external_host_name" {
 variable "common_tags" {
   type = "map"
 }
+
+variable "enable_ase" {
+  default = true
+}


### PR DESCRIPTION
Once the ASE to AKS migration is completed. This PR should be merged updating the value of 
enable_ase to be false for the environment that needs to delete the ASE.
e.g. 
>> aat.tfvars 
enable_ase = false
